### PR TITLE
feat: Enable keyless signing of the images

### DIFF
--- a/.github/workflows/Build_And_Publish_Docker_Images.yml
+++ b/.github/workflows/Build_And_Publish_Docker_Images.yml
@@ -6,9 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 env:
   IMAGE_NAME: tuleap-test-rest
@@ -20,9 +18,15 @@ jobs:
       matrix:
         os_base: ["el9"]
         php_base: ["php82", "php83"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          persist-credentials: false
       - name: Get lowercase base image name
         run: echo BASE_IMAGE_NAME="$(echo ${{ github.repository_owner }} | tr '[A-Z]' '[a-z]')" >> $GITHUB_ENV
       - name: Build image
@@ -38,8 +42,5 @@ jobs:
       - name: Publish image
         run: docker push ghcr.io/${{ env.BASE_IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ matrix.os_base }}-${{ matrix.php_base }}
       - name: Sign image
-        env:
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
         run: |
-          export VAULT_TOKEN=$(curl "$VAULT_ADDR"/v1/auth/approle/login --silent --fail -X POST --data '{"role_id": "${{ secrets.VAULT_ROLE_ID_SIGNING }}", "secret_id": "${{ secrets.VAULT_SECRET_ID_SIGNING }}"}' | jq -r '.auth.client_token')
-          cosign sign --yes --tlog-upload=true --key hashivault://tuleap-additional-tools-signing "$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/${{ env.BASE_IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ matrix.os_base }}-${{ matrix.php_base }})"
+          cosign sign --yes "$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/${{ env.BASE_IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ matrix.os_base }}-${{ matrix.php_base }})"

--- a/.github/workflows/Build_Docker_Image_PR.yml
+++ b/.github/workflows/Build_Docker_Image_PR.yml
@@ -3,8 +3,7 @@ name: Build Docker image
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   PHP_CURRENT: php82
@@ -15,8 +14,12 @@ jobs:
       matrix:
         os_base: ["el9"]
         php_base: ["php82", "php83"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          persist-credentials: false
       - name: Build image
         run: docker build -t test-build-${{ matrix.os_base }}-${{ matrix.php_base }} -f ${{ matrix.os_base }}.dockerfile --build-arg="PHP_BASE=${{ matrix.php_base }}" --build-arg="PHP_CURRENT=${{ env.PHP_CURRENT }}" .


### PR DESCRIPTION
This allow us to not rely on our internal infrastructure. Workflows have been slightly adjusted to be consistent and avoid some footguns.

Part of request #41087